### PR TITLE
Update to 3.26.41

### DIFF
--- a/store-theme/manifest.json
+++ b/store-theme/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "storeido",
   "name": "andrei",
-  "version": "3.26.40",
+  "version": "3.26.41",
   "builders": {
     "styles": "2.x",
     "store": "0.x",


### PR DESCRIPTION
- Fixed  rich text store-locator-mobile positioning on Mobile Version
- Removed  "__fold__.experimentalLazyAssets" from Home